### PR TITLE
Update version of github-tag-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@1.34.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
Update version from 1.26.0 to 1.34.0 so "main" is marked as release branch by default