### PR TITLE
Make release use Personal Access Token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.34.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
         WITH_V: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v*"
 
 jobs:
   release:
@@ -11,5 +11,5 @@ jobs:
     steps:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        repo_token: "${{ secrets.PAT }}"
         prerelease: false


### PR DESCRIPTION
GITHUB_TOKEN is not allowed to trigger workflows from itself, so we are changing to use new PAT